### PR TITLE
Adding DataCollection Parameter

### DIFF
--- a/AWSDSCBootstrapper.ps1
+++ b/AWSDSCBootstrapper.ps1
@@ -37,6 +37,7 @@ param (
     [string]
     $ExtensionVersion = "0.1.0.0",
 
+    [Parameter(HelpMessage = "Indicates whether to enable or disable telemetry sent to Microsoft. The only possible values are 'Enable' and 'Disable'.")]
     [ValidateSet('Enable', 'Disable', $null)]
     [string]
     $DataCollection

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # AWS DSC Bootstrapper
-AWS DSC Bootstrapper
+
+This service is provided under this [license](http://azure.microsoft.com/en-us/support/legal/) and this [privacy agreement](http://go.microsoft.com/fwlink/p/?linkid=131004&amp;clcid=0x409).
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # AWS DSC Bootstrapper
 
-This service is provided under this [license](http://azure.microsoft.com/en-us/support/legal/) and this [privacy agreement](http://go.microsoft.com/fwlink/p/?linkid=131004&amp;clcid=0x409).
+This service is provided under this [privacy agreement](http://go.microsoft.com/fwlink/p/?linkid=131004&amp;clcid=0x409).
 


### PR DESCRIPTION
The DataCollection parameter allows the user to opt-out of sending telemetry data about the 'AWS DSC Extension' to Microsoft.

Telemetry data collection by Microsoft for the 'AWS DSC Extension' is currently disabled for all AWS machines.
In order to enable telemetry collection, a new 'AWS DSC Extension' package will also need to be published, but this parameter to opt-out must be put in place here as well as in the AWS DSC Toolkit first.

The only valid values for the DataCollection parameter are 'Enable' and 'Disable'. There is also a $null value allowed which simulates not supplying the parameter.

Not specifying the DataCollection parameter or supplying the 'Enable' or $null values will allow Microsoft to collect telemetry data under this [privacy agreement](http://go.microsoft.com/fwlink/p/?linkid=131004&amp;clcid=0x409) which has been added to the README.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/awsbootstrapper/1)

<!-- Reviewable:end -->
